### PR TITLE
Add multi-workspace support for concurrent Go projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-Workspace Support**: Complete multi-workspace architecture allowing multiple Go projects in a single server instance
+- **WorkspaceManager Component**: New component to coordinate multiple Manager instances with dedicated gopls processes per workspace
+- **New MCP Tool**: `list_workspaces` tool to display all available workspaces and their running status
+- **Workspace Routing**: Intelligent request routing based on workspace parameter in MCP tool calls
+- **Enhanced Docker Support**: Multi-workspace Docker deployment with multiple volume mount examples
+- **Comprehensive Multi-Workspace Testing**: 47 tests covering single workspace, multiple workspaces, and workspace management scenarios
+
 ### Changed
 
-### Fixed
+- **BREAKING**: Replaced `-workspace` flag with `-workspaces` flag accepting comma-separated workspace paths
+- **BREAKING**: All MCP tools now require mandatory `workspace` parameter for workspace routing:
+  - `go_to_definition` requires `workspace` field
+  - `find_references` requires `workspace` field  
+  - `get_hover_info` requires `workspace` field
+- **BREAKING**: No backward compatibility - old single-workspace usage patterns no longer supported
+- Updated Dockerfile CMD to use `-workspaces` flag instead of `-workspace`
+- Enhanced documentation with multi-workspace usage examples and Docker deployment patterns
+- Updated command-line help and flag descriptions for multi-workspace usage
 
 ### Removed
+
+- **BREAKING**: Removed `-workspace` flag (replaced by `-workspaces`)
+- **BREAKING**: Removed automatic workspace discovery - explicit workspace specification now required
 
 ## [v0.2.1] - 2025-07-05
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 
 # Set entrypoint
 ENTRYPOINT ["/usr/local/bin/gopls-mcp"]
-CMD ["-workspace", "/workspace"]
+CMD ["-workspaces", "/workspace"]


### PR DESCRIPTION
## Summary
• Implements GitHub issue #11 by adding multi-workspace support
• Transforms single-workspace server into multi-workspace server  
• Eliminates need for multiple Docker deployments for multiple Go projects
• Adds WorkspaceManager component to coordinate multiple gopls processes

## Key Features
• **Multi-workspace architecture**: Handle multiple Go projects in single server instance
• **Workspace routing**: MCP tools route requests based on workspace parameter
• **New list_workspaces tool**: Shows all available workspaces and their status
• **Enhanced Docker support**: Multi-workspace deployment with volume mounting examples
• **Comprehensive testing**: 47 tests covering single and multi-workspace scenarios

## Breaking Changes
• Removed `-workspace` flag (replaced by `-workspaces` with comma-separated paths)
• All MCP tools now require `workspace` parameter for routing
• No backward compatibility with previous single-workspace patterns

## Benefits
• **Reduced deployment complexity**: Single container handles multiple Go projects
• **Resource efficiency**: Shared HTTP server and MCP infrastructure
• **Workspace isolation**: Each workspace maintains independent gopls state
• **Simplified management**: Single endpoint for multiple projects

## Test Plan
- [x] All existing tests pass (47/47)
- [x] Multi-workspace creation and management
- [x] Workspace routing for all MCP tools
- [x] Docker configuration updates
- [x] Command-line flag parsing
- [x] Error handling for invalid workspaces
- [x] Documentation and examples updated

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)